### PR TITLE
modify the template of the module

### DIFF
--- a/lib/firedoc-theme/markdown/partials/module.mdt
+++ b/lib/firedoc-theme/markdown/partials/module.mdt
@@ -48,11 +48,9 @@ This module is deprecated.
 {{#if hasEnum}}
 ### {{i18n.sidebar.ENUMS}}
 
-  {{#classes}}
-  {{#if isEnum}}
+  {{#enums}}
   - [{{name}}](../enums/{{name}}.md)
-  {{/if}}
-  {{/classes}}
+  {{/enums}}
 {{/if}}
 
 {{#if subModules}}


### PR DESCRIPTION
modify the template of the module.mdt ,  because the template file does not exist in the firedoc

fix the API docs, enums part lost problem.