### PR TITLE
add the mixins proper

### DIFF
--- a/lib/firedoc-theme/markdown/partials/class.mdt
+++ b/lib/firedoc-theme/markdown/partials/class.mdt
@@ -1,7 +1,7 @@
 ## `{{name}}` {{i18n.CLASS}}
 
 {{#if extends}}
-{{i18n.EXTENDS_FOR}} [`{{extends}}`]({{extends}}.md)
+{{i18n.EXTENDS_FOR}} [`{{extends}}`]({{extends}}.md){{#if uses}}{{#uses}}, [`{{this}}`]({{this}}.md)(mixin){{/uses}}{{/if}}
 {{/if}}
 
 {{#if foundAt}}


### PR DESCRIPTION
Re: https://github.com/cocos-creator/creator-api-docs/issues/64
In factor, the mixins exist, and this pr is used to modify the module to show the mixins Object(super).
![image](https://user-images.githubusercontent.com/35832931/44515245-9497af80-a6f4-11e8-884a-b74c8433f2df.png)
handlebars