### PR TITLE
md file has been deleted

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -288,7 +288,6 @@ All enums and classes are under `cc` module if not specified otherwise.
 
 - [Editor](editor/renderer/editor.md)
 - [Editor (Console Module)](editor/renderer/console.md)
-- [Editor.Audio](editor/renderer/audio.md)
 - [Editor.Dialog](editor/renderer/dialog.md)
 - [Editor.Ipc](editor/renderer/ipc.md)
 - [Editor.MainMenu](editor/renderer/main-menu.md)

--- a/zh/index.md
+++ b/zh/index.md
@@ -288,7 +288,6 @@ All enums and classes are under `cc` module if not specified otherwise.
 
 - [Editor](editor/renderer/editor.md)
 - [Editor (Console Module)](editor/renderer/console.md)
-- [Editor.Audio](editor/renderer/audio.md)
 - [Editor.Dialog](editor/renderer/dialog.md)
 - [Editor.Ipc](editor/renderer/ipc.md)
 - [Editor.MainMenu](editor/renderer/main-menu.md)


### PR DESCRIPTION
问题反馈 Editor.Audio 链接失效，原因： md 文件缺失，应该是删掉了。