### PR TITLE
add locals.js file from obsolete fold

### DIFF
--- a/lib/firedoc-theme/markdown/locals.js
+++ b/lib/firedoc-theme/markdown/locals.js
@@ -1,0 +1,7 @@
+
+var _ = require('underscore');
+  
+module.exports = function (modules, classes, locals) {
+  locals.modules = _.sortBy(modules, 'namespace');
+  locals.classes = _.sortBy(classes, 'namespace');
+};


### PR DESCRIPTION
In order to ignore the locals.js lost error report
This file won't have any effect to MD file generate

从模板文件里面拷贝的内容，用于 locals.js 用于预先排序在我们输出 md 文件之前，但是因为我们对 firedoc 的 hack，所以 locals.js 对 md 文件生成实际上没有影响。
![image](https://user-images.githubusercontent.com/35832931/56889559-4ae43d80-6aa9-11e9-9f5a-91e831ad732a.png)
