### PR TITLE
new globby version has compatibility issue in windows platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gitbook-plugin-sharing": "^1.0.2",
     "gitbook-plugin-splitter": "0.0.8",
     "gitbook-plugin-theme-default-customize": "git+https://github.com/cocos-creator/theme-default.git",
-    "globby": "6.1.0",
+    "globby": "^8.0.1",
     "gulp": "^3.9.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gitbook-plugin-sharing": "^1.0.2",
     "gitbook-plugin-splitter": "0.0.8",
     "gitbook-plugin-theme-default-customize": "git+https://github.com/cocos-creator/theme-default.git",
-    "globby": "^11.0.0",
+    "globby": "6.1.0",
     "gulp": "^3.9.1"
   },
   "scripts": {


### PR DESCRIPTION
globby 新版本在windows平台识别路径分隔符 双反斜杠 有问题，只能识别 /
@2youyou2  同学解决了该问题。