### PR TITLE
refine tween doc

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,7 @@ gulp.task('build-md', ['cp-apisrc'], function (cb) {
 
 
 function hackTweenDoc (input) {
-    return input.replace('export class Tween', 'export class Tween<T>');
+    return input.replace('export class Tween', 'export class Tween<T=any>');
 }
 
 gulp.task('build-tsd', ['cp-apisrc'], function (cb) {


### PR DESCRIPTION
fixed 

```js
class A {
    a = 1
}


var a: cc.Tween = cc.tween(new A)
 .to(1, {a: 2})
```