### PR TITLE
移除 http:

### DIFF
--- a/en/book.json
+++ b/en/book.json
@@ -38,15 +38,15 @@
                 "links": [
                     {
                         "name": "3.3",
-                        "link": "http://docs.cocos.com/creator/3.3/api/en"
+                        "link": "//docs.cocos.com/creator/3.3/api/en"
                     },
                     {
                         "name": "3.2",
-                        "link": "http://docs.cocos.com/creator/3.2/api/en"
+                        "link": "//docs.cocos.com/creator/3.2/api/en"
                     },
                     {
                         "name": "3.1",
-                        "link": "http://docs.cocos.com/creator/3.1/api/en"
+                        "link": "//docs.cocos.com/creator/3.1/api/en"
                     },
                     {
                         "name": "3.0",

--- a/zh/book.json
+++ b/zh/book.json
@@ -52,15 +52,15 @@
                 "links": [
                     {
                         "name": "3.3",
-                        "link": "http://docs.cocos.com/creator/3.3/api/zh"
+                        "link": "//docs.cocos.com/creator/3.3/api/zh"
                     },
                     {
                         "name": "3.2",
-                        "link": "http://docs.cocos.com/creator/3.2/api/zh"
+                        "link": "//docs.cocos.com/creator/3.2/api/zh"
                     },
                     {
                         "name": "3.1",
-                        "link": "http://docs.cocos.com/creator/3.1/api/zh"
+                        "link": "//docs.cocos.com/creator/3.1/api/zh"
                     },
                     {
                         "name": "3.0",


### PR DESCRIPTION
移除 book.json 中跳转链接的 `http:`，与之前的版本保持一致